### PR TITLE
Fixing the button display in GitHub-Diff-Whitespace script

### DIFF
--- a/github-diff-whitespace/chrome/script.js
+++ b/github-diff-whitespace/chrome/script.js
@@ -20,9 +20,9 @@
 
   var objectToQueryString = function( params ){
     var values = [];
-    for( param in params ){
-      var value = ( params[ param ] == null ? '' : params[ param ] );
-      values.push( encodeURIComponent( param ) + '=' + encodeURIComponent( value ) )
+    for( var param in params ){
+      var value = ( params[ param ] === null ? '' : params[ param ] );
+      values.push( encodeURIComponent( param ) + '=' + encodeURIComponent( value ) );
     }
     return values.join( '&' ).replace( /%20/g, '+' );
   };
@@ -49,7 +49,7 @@
     a.appendChild(code);
 
     button_group.insertBefore( a, button_group.firstChild );
-  }
+  };
 
   var addWhitespaceToggleButtons = function( querystring ){
     Array.prototype.forEach.call(
@@ -61,7 +61,7 @@
   };
 
   var invertButtonGradients = function(){
-    var sheet = document.createElement('style')
+    var sheet = document.createElement('style');
     var selector = button_group_selector + ' .' + toggler_classname;
     sheet.innerHTML = selector + "{ background: -moz-linear-gradient(#EAEAEA,#FAFAFA);\
                                     background: -webkit-linear-gradient(#EAEAEA,#FAFAFA);}" +

--- a/github-diff-whitespace/github-diff-whitespace.user.js
+++ b/github-diff-whitespace/github-diff-whitespace.user.js
@@ -20,9 +20,9 @@
 
   var objectToQueryString = function( params ){
     var values = [];
-    for( param in params ){
-      var value = ( params[ param ] == null ? '' : params[ param ] );
-      values.push( encodeURIComponent( param ) + '=' + encodeURIComponent( value ) )
+    for( var param in params ){
+      var value = ( params[ param ] === null ? '' : params[ param ] );
+      values.push( encodeURIComponent( param ) + '=' + encodeURIComponent( value ) );
     }
     return values.join( '&' ).replace( /%20/g, '+' );
   };
@@ -49,7 +49,7 @@
     a.appendChild(code);
 
     button_group.insertBefore( a, button_group.firstChild );
-  }
+  };
 
   var addWhitespaceToggleButtons = function( querystring ){
     Array.prototype.forEach.call(
@@ -61,7 +61,7 @@
   };
 
   var invertButtonGradients = function(){
-    var sheet = document.createElement('style')
+    var sheet = document.createElement('style');
     var selector = button_group_selector + ' .' + toggler_classname;
     sheet.innerHTML = selector + "{ background: -moz-linear-gradient(#EAEAEA,#FAFAFA);\
                                     background: -webkit-linear-gradient(#EAEAEA,#FAFAFA);}" +


### PR DESCRIPTION
Hi!

The whitespace toggle button didn't display correctly on Chromium 26 (different height) and Firefox 19 (buttons not grouped).

This fixes it for both Chrome/ium and Firefox. I also cleaned up a few JSHint warnings.
