### PR TITLE
Update button selector for new GitHub markup

### DIFF
--- a/github-diff-whitespace/github-diff-whitespace.js
+++ b/github-diff-whitespace/github-diff-whitespace.js
@@ -61,7 +61,7 @@
   };
 
 
-  var button_group_selector = '.diff-view .actions .button-group';
+  var button_group_selector = '#files .meta .actions';
   var toggler_classname = 'toggle-whitespace';
   var params = querystringToObject( querystring );
   var whitespace = Boolean(params.w);


### PR DESCRIPTION
Current version of Chrome extension is not working because
the CSS classes of the diff action buttons has changed.
The selector ".diff-view .actions .button-group" should be
replaced with "#files .meta .actions".
