### PR TITLE
Move "Toggle Whitespace" text to aria-label

### DIFF
--- a/github-diff-whitespace/github-diff-whitespace.js
+++ b/github-diff-whitespace/github-diff-whitespace.js
@@ -34,7 +34,7 @@
     var a = document.createElement( 'a' );
     a.className = button_group.querySelector( 'a' ).className + ' ' + toggler_classname;
     a.href = '?' + querystring;
-    a.title = 'Toggle Whitespace';
+    a.setAttribute( 'aria-label', 'Toggle Whitespace' );
     a.textContent = ' \u2423';
     a.appendChild(code);
 


### PR DESCRIPTION
GitHub now seems to use the "aria-label" attribute (part of a move to
Bootstrap, I'd guess) to display text on hover rather than "title".
